### PR TITLE
Add 21-day cooldown to Dependabot composer updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
 version: 2
-
 updates:
   - package-ecosystem: composer
     directory: "/"
@@ -9,3 +8,5 @@ updates:
       timezone: Europe/London
     open-pull-requests-limit: 10
     versioning-strategy: increase
+    cooldown:
+      default-days: 21


### PR DESCRIPTION
Add 21-day cooldown to Dependabot composer updates to reduce supply chain attack surface.

Related: https://app.clickup.com/t/86c5dhpyd